### PR TITLE
Enforce joint limits and singularity avoidance

### DIFF
--- a/coordinated_motion_controllers/include/coordinated_motion_controllers/coordinated_controller_base.hpp
+++ b/coordinated_motion_controllers/include/coordinated_motion_controllers/coordinated_controller_base.hpp
@@ -83,6 +83,10 @@ protected:
   void write_robot_command(const KDL::JntArrayVel& cmd);
   void write_positioner_command(const ctrl::VectorND& cmd);
 
+  // Utility functions
+  bool check_manipulability(const KDL::Jacobian& jac);
+
+  // Callbacks
   using QueryPose = taskspace_control_msgs::srv::QueryPose;
   virtual bool queryPoseServiceCb(const std::shared_ptr<QueryPose::Request> req,
                                   std::shared_ptr<QueryPose::Response> resp);

--- a/coordinated_motion_controllers/include/coordinated_motion_controllers/coordinated_controller_base.hpp
+++ b/coordinated_motion_controllers/include/coordinated_motion_controllers/coordinated_controller_base.hpp
@@ -20,9 +20,10 @@
 #include <kdl/chainjnttojacsolver.hpp>
 #include <kdl/chainfksolverpos_recursive.hpp>
 
-// ROS2 controller interface
+// ROS2 control
 #include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "joint_limits/joint_limits.hpp"
 
 // ROS2 messages
 #include "sensor_msgs/msg/joint_state.hpp"
@@ -51,9 +52,6 @@ class CoordinatedControllerBase
   : public controller_interface::ControllerInterface
 {
 public:
-  using QueryPoseSrv = taskspace_control_msgs::srv::QueryPose;
-  using QueryPoseService = rclcpp::Service<QueryPoseSrv>::SharedPtr;
-
   virtual controller_interface::InterfaceConfiguration
   command_interface_configuration() const override;
 
@@ -78,6 +76,7 @@ public:
   on_shutdown(const rclcpp_lifecycle::State& previous_state) override;
 
 protected:
+  // Hardware interface methods
   void read_state_from_hardware(KDL::JntArrayVel& state);
   void get_combined_state(KDL::JntArrayVel& state);
   void stop_motion();
@@ -106,8 +105,7 @@ protected:
 
   // Kinematics
   KDL::Chain robot_chain_, coordinated_chain_;
-  KDL::JntArray upper_pos_limits_;
-  KDL::JntArray lower_pos_limits_;
+  std::vector<joint_limits::JointLimits> joint_limits_;
   std::unique_ptr<KDL::ChainFkSolverPos_recursive> coordinated_fk_solver_;
 
   // State tracking

--- a/coordinated_motion_controllers/src/axially_symmetric_controller.cpp
+++ b/coordinated_motion_controllers/src/axially_symmetric_controller.cpp
@@ -33,6 +33,12 @@ controller_interface::return_type AxiallySymmetricController::update(
   KDL::Jacobian coord_jac(n_robot_joints_ + n_pos_joints_);
   coordinated_jacobian_solver_->JntToJac(combined_state.q, coord_jac);
 
+  // Safety: bail out near singularities
+  if (!check_manipulability(coord_jac))
+  {
+    return controller_interface::return_type::OK;
+  }
+
   KDL::Frame pose_kdl;
   coordinated_fk_solver_->JntToCart(combined_state.q, pose_kdl);
 

--- a/coordinated_motion_controllers/src/axially_symmetric_controller.cpp
+++ b/coordinated_motion_controllers/src/axially_symmetric_controller.cpp
@@ -68,10 +68,9 @@ controller_interface::return_type AxiallySymmetricController::update(
   ctrl::VectorND joint_cmd =
       Jr_pinv * (cart_cmd - Jp * q_dot_pos) + (I - Jr_pinv * Jr) * h;
 
-  ctrl::VectorND new_position =
-      joint_state_.q.data + (joint_cmd * period.seconds());
-
-  auto cmd = ctrl::transformEigenToKDL(new_position, joint_cmd);
+  KDL::JntArray q_cmd = ctrl::transformEigenToKDL(joint_cmd);
+  auto cmd = ctrl::create_command(joint_state_.q, q_cmd, joint_limits_,
+                                  period.seconds());
   write_robot_command(cmd);
 
   // --- Suggested positioner command ---

--- a/coordinated_motion_controllers/src/coordinated_controller_base.cpp
+++ b/coordinated_motion_controllers/src/coordinated_controller_base.cpp
@@ -20,6 +20,7 @@
 #include "coordinated_motion_controllers/positioner_state_interface/topic_state_interface.hpp"
 #include "coordinated_motion_controllers/positioner_state_interface/loaned_state_interface.hpp"
 
+#include "taskspace_controllers/utility.hpp"
 #include "urdf/model.h"
 
 #include <kdl/jntarray.hpp>
@@ -385,6 +386,25 @@ void CoordinatedControllerBase::stop_motion()
       command_interfaces_[vel_ind * n_robot_joints_ + joint_ind].set_value(0.0);
     }
   }
+
+  // Zero position velocity suggestion
+  write_positioner_command(ctrl::VectorND::Zero(n_pos_joints_));
+}
+
+bool CoordinatedControllerBase::check_manipulability(const KDL::Jacobian& jac)
+{
+  const double w = ctrl::compute_manipulability(jac);
+  if (w < params_.manipulability_threshold)
+  {
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(),
+                         500 /*ms*/,
+                         "Manipulability (%.6f) below threshold (%.6f) — "
+                         "zeroing output.",
+                         w, params_.manipulability_threshold);
+    stop_motion();
+    return false;
+  }
+  return true;
 }
 
 bool CoordinatedControllerBase::queryPoseServiceCb(

--- a/coordinated_motion_controllers/src/coordinated_controller_base.cpp
+++ b/coordinated_motion_controllers/src/coordinated_controller_base.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "controller_interface/controller_interface_base.hpp"
 #include "coordinated_motion_controllers/coordinated_controller_base.hpp"
+
+#include "joint_limits/joint_limits_urdf.hpp"
 
 // positioner state interfaces
 #include "coordinated_motion_controllers/positioner_state_interface/topic_state_interface.hpp"
@@ -186,8 +187,8 @@ controller_interface::CallbackReturn CoordinatedControllerBase::on_configure(
   coordinated_fk_solver_ =
       std::make_unique<KDL::ChainFkSolverPos_recursive>(coordinated_chain_);
 
-  upper_pos_limits_.resize(n_robot_joints_);
-  lower_pos_limits_.resize(n_robot_joints_);
+  // Initialize the joint limits from the urdf
+  joint_limits_.resize(n_robot_joints_);
   for (size_t i = 0; i < n_robot_joints_; ++i)
   {
     const auto& jn = robot_joint_names_[i];
@@ -197,22 +198,8 @@ controller_interface::CallbackReturn CoordinatedControllerBase::on_configure(
       RCLCPP_ERROR(logger, "Joint '%s' not found in URDF.", jn.c_str());
       return controller_interface::CallbackReturn::ERROR;
     }
-    if (j->type == urdf::Joint::CONTINUOUS)
-    {
-      upper_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
-      lower_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
-    }
-    else if (j->limits)
-    {
-      upper_pos_limits_(i) = j->limits->upper;
-      lower_pos_limits_(i) = j->limits->lower;
-    }
-    else
-    {
-      RCLCPP_WARN(logger, "Joint %s has no limits; using NaN.", jn.c_str());
-      upper_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
-      lower_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
-    }
+
+    joint_limits::getJointLimits(j, joint_limits_[i]);
   }
 
   // Create positioner state interface

--- a/coordinated_motion_controllers/src/coordinated_controller_base_parameters.yaml
+++ b/coordinated_motion_controllers/src/coordinated_controller_base_parameters.yaml
@@ -39,3 +39,8 @@ coordinated_controller_base:
     description: "Name of the positioner feedback topic",
     read_only: true,
   }
+  manipulability_threshold: {
+    type: double,
+    default_value: 0.001,
+    description: "Minimum manipulability index w = sqrt(det(J*J^T)) below which output is zeroed."
+  }

--- a/coordinated_motion_controllers/src/pose_controller.cpp
+++ b/coordinated_motion_controllers/src/pose_controller.cpp
@@ -14,7 +14,6 @@
 
 #include "controller_interface/controller_interface_base.hpp"
 #include "coordinated_motion_controllers/pose_controller.hpp"
-#include "axially_symmetric_controllers/utility.hpp"
 
 namespace coordinated_motion_controllers
 {
@@ -178,6 +177,12 @@ controller_interface::return_type PoseController::update(
 
   KDL::Jacobian coord_jac(n_robot_joints_ + n_pos_joints_);
   coordinated_jacobian_solver_->JntToJac(combined_state.q, coord_jac);
+
+  // Safety: bail out near singularities
+  if (!check_manipulability(coord_jac))
+  {
+    return controller_interface::return_type::OK;
+  }
 
   KDL::Frame pose_kdl;
   coordinated_fk_solver_->JntToCart(combined_state.q, pose_kdl);

--- a/coordinated_motion_controllers/src/pose_controller.cpp
+++ b/coordinated_motion_controllers/src/pose_controller.cpp
@@ -92,8 +92,7 @@ PoseController::on_configure(const rclcpp_lifecycle::State& previous_state)
     return CallbackReturn::FAILURE;
   }
 
-  if (!rr_objective_->init(node, robot_chain_, upper_pos_limits_,
-                           lower_pos_limits_))
+  if (!rr_objective_->init(node, robot_chain_, joint_limits_))
   {
     RCLCPP_ERROR(node->get_logger(),
                  "Failed to initialize redundancy resolution objective.");
@@ -216,10 +215,9 @@ controller_interface::return_type PoseController::update(
   ctrl::VectorND joint_cmd =
       Jr_pinv * (cart_cmd - Jp * q_dot_pos) + (I - Jr_pinv * Jr) * h;
 
-  ctrl::VectorND new_position =
-      joint_state_.q.data + (joint_cmd * period.seconds());
-
-  auto cmd = ctrl::transformEigenToKDL(new_position, joint_cmd);
+  KDL::JntArray q_cmd = ctrl::transformEigenToKDL(joint_cmd);
+  auto cmd = ctrl::create_command(joint_state_.q, q_cmd, joint_limits_,
+                                  period.seconds());
   write_robot_command(cmd);
 
   // --- Suggested positioner command ---


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Adds singularity and joint-limit avoidance functionality for safe operation.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  closes #4, closes #5 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | `medusa_control_sandbox` |

---

## Description of contribution in a few bullet points
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

- [X] Applies joint limits in an identical fashion to https://github.com/alexarbogast/taskspace_control/pull/7
- [X] Applies singularity avoidance in an identical fashion to https://github.com/alexarbogast/taskspace_control/pull/8

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

Drove one robot to the joint limit extents an observed no joint limit violations.

__Joint Limit Avoidance__
Drive medusa robot 1 to the limits
`coordinated_control_test_rob1.py`
```python
    def test_limits(self):
        tf = 20
        p_start = np.array([-0.6, 0.0, 0.005])
        p_end = np.array([-0.6, -0.6, -2])

        self.movel(p_start, self.static_orient, 3)
        self.execute_linear_path(
            p_start, p_end, self.static_orient, self.static_orient, tf
        )
```

__Singularity Avoidance__
Drive medusa robot2 to singularity
`coordinated_control_test_rob2.py`
```python
    def test_line(self):
        tf = 10
        p_start = np.array([0.1, 0, 0.00])
        p_end = np.array([0.1, 0, 2.5])
        self.path_viz.visualize_path([p_start, p_end], "positioner")

        self.movel(p_start, self.static_orient, 3)
        self.execute_linear_path(
            p_start, p_end, self.static_orient, self.static_orient, tf
        )
        self.path_viz.reset()
```